### PR TITLE
adjust white in the dark variant

### DIFF
--- a/colors/gruvbox-material-dark-hard.conf
+++ b/colors/gruvbox-material-dark-hard.conf
@@ -1,14 +1,14 @@
 background #1d2021
-foreground #d8be95
+foreground #d6c094
 
-selection_background #d8be95
+selection_background #d6c094
 selection_foreground #1d2021
 
 cursor #a89984
 cursor_text_color background
 
 active_tab_background #1d2021
-active_tab_foreground #d8be95
+active_tab_foreground #d6c094
 active_tab_font_style bold
 inactive_tab_background #1d2021
 inactive_tab_foreground #a89984
@@ -43,5 +43,5 @@ color6 #89b482
 color14 #89b482
 
 # White
-color7 #d8be95
-color15 #d8be95
+color7 #d6c094
+color15 #d6c094

--- a/colors/gruvbox-material-dark-medium.conf
+++ b/colors/gruvbox-material-dark-medium.conf
@@ -1,14 +1,14 @@
 background #282828
-foreground #d8be95
+foreground #d6c094
 
-selection_background #d8be95
+selection_background #d6c094
 selection_foreground #282828
 
 cursor #a89984
 cursor_text_color background
 
 active_tab_background #282828
-active_tab_foreground #d8be95
+active_tab_foreground #d6c094
 active_tab_font_style bold
 inactive_tab_background #282828
 inactive_tab_foreground #a89984
@@ -43,5 +43,5 @@ color6 #89b482
 color14 #89b482
 
 # White
-color7 #d8be95
-color15 #d8be95
+color7 #d6c094
+color15 #d6c094

--- a/colors/gruvbox-material-dark-soft.conf
+++ b/colors/gruvbox-material-dark-soft.conf
@@ -1,14 +1,14 @@
 background #32302f
-foreground #d8be95
+foreground #d6c094
 
-selection_background #d8be95
+selection_background #d6c094
 selection_foreground #32302f
 
 cursor #a89984
 cursor_text_color background
 
 active_tab_background #32302f
-active_tab_foreground #d8be95
+active_tab_foreground #d6c094
 active_tab_font_style bold
 inactive_tab_background #32302f
 inactive_tab_foreground #a89984
@@ -43,5 +43,5 @@ color6 #89b482
 color14 #89b482
 
 # White
-color7 #d8be95
-color15 #d8be95
+color7 #d6c094
+color15 #d6c094


### PR DESCRIPTION
OK, it's my fault. White needs to be adjusted again.

I found that the same color has a very different display effect on different monitors. The display of the "white" color in the dark variant is very red on at least 2 monitors.

I used to think that there would not be too many adjustments in the future, but it may not seem right now. Anyway, if there is any adjustment, I will open a PR. 